### PR TITLE
Rev iOS Version

### DIFF
--- a/AzureMapsControl.podspec
+++ b/AzureMapsControl.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
 
     s.platform = :ios
     s.swift_version = 5
-    s.ios.deployment_target = "13.0"
+    s.ios.deployment_target = "14.0"
 
     s.dependency "MSAL"
 end

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "AzureMapsControl",
-    platforms: [.iOS(.v13)],
+    platforms: [.iOS(.v14)],
     products: [
         .library(
             name: "AzureMapsControl",


### PR DESCRIPTION
The MapControl currently requires iOS 13 where the dependency MSAL requires iOS 14. This PR revs the min requirement in the MapControl. Without this fix, one observes the following error:

The package product 'MSAL' requires minimum platform version 14.0 for the iOS platform, but this target supports 13.0 (in target 'MapControlDependencies' from project 'AzureMapsControl')

----------------------------------------

SchemeBuildError: Failed to build the scheme "DonkeyMap"

The package product 'MSAL' requires minimum platform version 14.0 for the iOS platform, but this target supports 13.0 (in target 'MapControlDependencies' from project 'AzureMapsControl')

Build target MapControlDependencies:
error: The package product 'MSAL' requires minimum platform version 14.0 for the iOS platform, but this target supports 13.0 (in target 'MapControlDependencies' from project 'AzureMapsControl')
